### PR TITLE
Drop support for Python <3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: python
 sudo: false
 python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - 3.4
   - 3.5
   - 3.6
+  - 3.7
+  - 3.8
   - pypy
 
 matrix:

--- a/pydocstring/cli.py
+++ b/pydocstring/cli.py
@@ -28,7 +28,6 @@ You may also want to provide the ``-f`` flag with the formatter you want to use.
     --version             show program's version number and exit
 
 """
-from __future__ import print_function #pragma: no cover
 import sys #pragma: no cover
 import os #pragma: no cover
 import argparse #pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -20,12 +20,10 @@ classifiers=[
     'Environment :: Win32 (MS Windows)',
     'Intended Audience :: Developers',
     'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3.2',
-    'Programming Language :: Python :: 3.3',
-    'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'Topic :: Software Development :: Documentation',
 ]
 
@@ -49,6 +47,6 @@ setup(
         ],
     },
     install_requires=[
-        'parso==0.1.1'
+        'parso>=0.1.1'
     ]
 )


### PR DESCRIPTION
Hi,

First of all, thanks for the package!

I wanted to check if newer parso releases were compatible (which at least for now seem compatible locally, I hope travis build pass too), basically in order to get less pip warnings.

I also figured it would be useful to remove from the package info and the CI the unsupported python versions (I removed 2.7 too even though it has a month left).

Feel free to review and suggest changes. Hope it helps! 