### PR TITLE
Apply Black on code base.

### DIFF
--- a/pydocstring/cli.py
+++ b/pydocstring/cli.py
@@ -28,38 +28,43 @@ You may also want to provide the ``-f`` flag with the formatter you want to use.
     --version             show program's version number and exit
 
 """
-import sys #pragma: no cover
-import os #pragma: no cover
-import argparse #pragma: no cover
-import ast #pragma: no cover
-import pydocstring #pragma: no cover
-from pydocstring import exc #pragma: no cover
+import sys  # pragma: no cover
+import os  # pragma: no cover
+import argparse  # pragma: no cover
+import ast  # pragma: no cover
+import pydocstring  # pragma: no cover
+from pydocstring import exc  # pragma: no cover
 
 
-def main(): #pragma: no cover
+def main():  # pragma: no cover
     """
     CLI entrypoint
     """
     parser = argparse.ArgumentParser(prog="pydocstring")
-    parser.add_argument("source",
-                        type=str,
-                        help="Source code to process, or the path to a file")
-    parser.add_argument("position",
-                        nargs="?",
-                        type=ast.literal_eval,
-                        help="Position of the cursor in the document, defaults to the end. \
-                            Row, then column, presented as a string python tuple. E.g. '(10, 15)'")
-    parser.add_argument("-f", "--formatter",
-                        choices=['google', 'numpy', 'reST'],
-                        default='google',
-                        type=str,
-                        help="docstring formatter to use")
-    parser.add_argument('--version',
-                        action='version',
-                        version='%(prog)s {0}'.format(pydocstring.__version__))
-    parser.add_argument('--debug',
-                        action="store_true",
-                        help="Show stacktraces")
+    parser.add_argument(
+        "source", type=str, help="Source code to process, or the path to a file"
+    )
+    parser.add_argument(
+        "position",
+        nargs="?",
+        type=ast.literal_eval,
+        help="Position of the cursor in the document, defaults to the end. \
+                            Row, then column, presented as a string python tuple. E.g. '(10, 15)'",
+    )
+    parser.add_argument(
+        "-f",
+        "--formatter",
+        choices=["google", "numpy", "reST"],
+        default="google",
+        type=str,
+        help="docstring formatter to use",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s {0}".format(pydocstring.__version__),
+    )
+    parser.add_argument("--debug", action="store_true", help="Show stacktraces")
     args = parser.parse_args()
     source = args.source
 
@@ -72,9 +77,9 @@ def main(): #pragma: no cover
     print(position)
 
     try:
-        output = pydocstring.generate_docstring(source,
-                                                position=position,
-                                                formatter=args.formatter)
+        output = pydocstring.generate_docstring(
+            source, position=position, formatter=args.formatter
+        )
         print('"""\n' + output + '"""\n')
     except Exception as ex:
         if args.debug:

--- a/pydocstring/exc.py
+++ b/pydocstring/exc.py
@@ -7,6 +7,7 @@ class InvalidFormatterError(Exception):
     """
     Provided name of formatter is not one supported
     """
+
     pass
 
 
@@ -14,4 +15,5 @@ class FailedToGenerateDocstringError(Exception):
     """
     Could not generate a docstring for the given code and position
     """
+
     pass

--- a/pydocstring/format_utils.py
+++ b/pydocstring/format_utils.py
@@ -17,15 +17,12 @@ def safe_determine_type(string):
         return ast.literal_eval(string).__class__.__name__
     except ValueError:
         try:
-            if (
-                string.startswith('set(')
-                or
-                isinstance(ast.literal_eval(string.replace(
-                    '{', '[').replace('}', ']')), list)
+            if string.startswith("set(") or isinstance(
+                ast.literal_eval(string.replace("{", "[").replace("}", "]")), list
             ):
-                return 'set'
+                return "set"
         except ValueError:
-            return 'TYPE'
+            return "TYPE"
 
 
 def get_param_info(param):
@@ -39,8 +36,9 @@ def get_param_info(param):
         tuple: name, type, default
     """
     param_type = param.annotation.value if param.annotation else "TYPE"
-    param_default = " default: ``{0}``".format(
-        param.default.get_code()) if param.default else ""
+    param_default = (
+        " default: ``{0}``".format(param.default.get_code()) if param.default else ""
+    )
     if param_default and not param.annotation:
         param_type = safe_determine_type(param.default.get_code())
     return param.name.value, param_type, param_default
@@ -57,7 +55,7 @@ def get_return_info(ret, annotation):
     Returns:
         tuple: type, expression after 'return' keyword
     """
-    ret_type = annotation.value if annotation else 'TYPE'
+    ret_type = annotation.value if annotation else "TYPE"
     expression = "".join(x.get_code().strip() for x in ret.children[1:])
     expression = " ".join(expression.split())
     return ret_type, expression
@@ -74,6 +72,6 @@ def get_exception_name(node):
         str: The exception name
     """
     name = node.children[1]
-    while not name.type == 'name':
+    while not name.type == "name":
         name = name.children[0]
     return name.value

--- a/pydocstring/formatter.py
+++ b/pydocstring/formatter.py
@@ -1,10 +1,22 @@
 """
 Google Docstring Formatter
 """
-from parso.python.tree import Class, ExprStmt, Function, KeywordStatement, Module, Name, PythonNode
+from parso.python.tree import (
+    Class,
+    ExprStmt,
+    Function,
+    KeywordStatement,
+    Module,
+    Name,
+    PythonNode,
+)
 
-from pydocstring.format_utils import (get_exception_name, get_param_info, get_return_info,
-                                      safe_determine_type)
+from pydocstring.format_utils import (
+    get_exception_name,
+    get_param_info,
+    get_return_info,
+    safe_determine_type,
+)
 
 
 def function_docstring(parso_function, formatter):


### PR DESCRIPTION
All I did was to take `origin/master` code and run the following command:

```bash
black pydocstring/
```

Why doing this ?
So that https://github.com/robodair/pydocstring/pull/13 does not contain any
changes related to black (that my editor auto-perform). The PR will be lengthy
enough without style changes.