### PR TITLE
Create a docstring enum

### DIFF
--- a/pydocstring/__init__.py
+++ b/pydocstring/__init__.py
@@ -7,12 +7,23 @@ __version__ = "0.2.1"
 
 import parso
 from parso.python.tree import BaseNode, search_ancestor
+from strenum import StrEnum
 
 import pydocstring.formatter
 from pydocstring import exc
 
+class DocstringStyle(StrEnum):
+    GOOGLE = "google"
+    NUMPY = "numpy"
+    REST = "reST"
+
+    @classmethod
+    def list_values(cls):
+        return [x.value for x in cls]
+
+
 FORMATTER = {
-    "google": {
+    DocstringStyle.GOOGLE: {
         "start_args_block": "\n\nArgs:\n",
         "param_placeholder": "    {0} ({1}): {2}\n",
         "param_placeholder_args": "    *{0}: {1}\n",
@@ -27,7 +38,7 @@ FORMATTER = {
         "start_attributes": "\n\nAttributes:\n",
         "attribute_placeholder": "    {0} ({1}): {2}\n",
     },
-    "numpy": {
+    DocstringStyle.NUMPY: {
         "start_args_block": "\n\n    Parameters\n    ----------\n",
         "param_placeholder": "    {0} : {1}\n        {2}\n",
         "param_placeholder_args": "    *{0}\n        {1}\n",
@@ -42,7 +53,7 @@ FORMATTER = {
         "start_attributes": "\n\n    Attributes\n    ----------\n",
         "attribute_placeholder": "    {0} : {1}\n        {2}\n",
     },
-    "reST": {
+    DocstringStyle.REST: {
         "start_args_block": "\n\n",
         "param_placeholder": ":param {0}: {2}\n:type {0}: {1}\n",
         "param_placeholder_args": ":param *{0}: {1}\n",
@@ -60,7 +71,7 @@ FORMATTER = {
 }
 
 
-def generate_docstring(source, position=(1, 0), formatter="google", autocomplete=False):
+def generate_docstring(source: str, position=(1, 0), formatter=DocstringStyle.GOOGLE, autocomplete=False):
     """Generate a docstring
 
     Args:

--- a/pydocstring/cli.py
+++ b/pydocstring/cli.py
@@ -33,7 +33,7 @@ import os  # pragma: no cover
 import argparse  # pragma: no cover
 import ast  # pragma: no cover
 import pydocstring  # pragma: no cover
-from pydocstring import exc  # pragma: no cover
+from pydocstring import DocstringStyle  # pragma: no cover
 
 
 def main():  # pragma: no cover
@@ -54,8 +54,8 @@ def main():  # pragma: no cover
     parser.add_argument(
         "-f",
         "--formatter",
-        choices=["google", "numpy", "reST"],
-        default="google",
+        choices=DocstringStyle.list_values(),
+        default=DocstringStyle.GOOGLE,
         type=str,
         help="docstring formatter to use",
     )

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         ],
     },
     install_requires=[
-        'parso>=0.1.1'
+        'parso>=0.1.1',
+        'strenum>=0.4.0'
     ]
 )


### PR DESCRIPTION
Move the different docstring style options into an enum for easier referencing through the code